### PR TITLE
chore: modernize Terraform and provider versions

### DIFF
--- a/dmz_spoke_openvpn/Commercial/versions.tf
+++ b/dmz_spoke_openvpn/Commercial/versions.tf
@@ -18,7 +18,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~>3.36"
+      version = "~> 3.116"
 
     }
     azuread = {
@@ -31,7 +31,7 @@ terraform {
     }
   }
 
-  required_version = ">= 1.3"
+  required_version = ">= 1.9"
 
   /*  backend "azurerm" {
     resource_group_name  = "afmpe-network-artifacts-rg"

--- a/dmz_spoke_openvpn/Government/versions.tf
+++ b/dmz_spoke_openvpn/Government/versions.tf
@@ -18,7 +18,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~>3.36"
+      version = "~> 3.116"
 
     }
     azuread = {
@@ -31,7 +31,7 @@ terraform {
     }
   }
 
-  required_version = ">= 1.3"
+  required_version = ">= 1.9"
 
   /*  backend "azurerm" {
     resource_group_name  = "afmpe-network-artifacts-rg"

--- a/dmz_spoke_openvpn/modules/dmz_spoke/versions.tf
+++ b/dmz_spoke_openvpn/modules/dmz_spoke/versions.tf
@@ -1,10 +1,12 @@
 terraform {
   required_providers {
     azurerm = {
-      source = "hashicorp/azurerm"
+      source  = "hashicorp/azurerm"
+      version = "~> 3.116"
     }
     azurenoopsutils = {
-      source = "POps-Rox/azurenoopsutils"
+      source  = "POps-Rox/azurenoopsutils"
+      version = "~> 1.0.4"
     }
   }
 }

--- a/redirect_spoke/modules/redirector_spoke/versions.tf
+++ b/redirect_spoke/modules/redirector_spoke/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 2.65.0"
+      version = "~> 3.116"
     }
     azurenoopsutils = {
       source  = "POps-Rox/azurenoopsutils"


### PR DESCRIPTION
## Summary
Modernize version constraints across all 5 modules.

### Changes
- `redirect_spoke`: azurerm `>= 2.65.0` → `~> 3.116` (code already v3-compatible)
- `dmz_spoke_openvpn/Commercial` & `Government`: TF `>= 1.3` → `>= 1.9`, azurerm `~>3.36` → `~> 3.116`
- `dmz_spoke_openvpn/modules/dmz_spoke`: Added missing version constraints
- Deprecated `azurerm_firewall_nat_rule_collection` was already commented out and replaced with v3-compatible `azurerm_firewall_policy_rule_collection_group`

Closes #1